### PR TITLE
feat(tables): support empty cells

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ const microdown = function () {
       /((^|\n)\|.+)+/g,
       chain('table', /^.*(\n\|---.*?)?$/gm,
         (match, subline) =>
-          chain('tr', /\|(-?)([^|]+)\1(\|$)?/gm,
+          chain('tr', /\|(-?)([^|]*)\1(\|$)?/gm,
             (match, type, text) => tag(type || subline ? 'th' : 'td', inlineBlock(text)),
           )(match.slice(0, match.length - (subline || '').length)),
       ),

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -121,6 +121,16 @@ describe('md.parse()', () => {
       );
     });
   });
+
+  describe('tables', () => {
+    it('parses basic', () => {
+      expect(md.block('|a|b|\n|---|---|\n|1|2|')).toEqual('<table><tr><th>a</th><th>b</th></tr>\n<tr><td>1</td><td>2</td></tr></table>');
+    });
+    it('parses empty cells', () => {
+      expect(md.block('|a|b|\n|---|---|\n|||')).toEqual('<table><tr><th>a</th><th>b</th></tr>\n<tr><td></td><td></td></tr></table>');
+    });
+  });
+
   //
   // describe('lists', () => {
   //   it('parses an unordered list with *', () => {


### PR DESCRIPTION
Tables didn't support an empty cell/column `|||` would just get printed verbatim.

This PR fixes that, hopefully it didn't break anything else :)

🌴 