### PR TITLE
fix(lists): do not double parse sub lists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const microdown = function () {
     list = (text, temp) => {
       temp = text.match(/^[+-]/m) ? 'ul' : 'ol';
       return text ?
-        `<${temp}>${text.replace(/(?:[+-]|\d+\.) +(.*)\n?(([ \t].*\n?)*)/g, (match, a, b) => `<li>${inlineBlock(`${a}\n${outdent(b || '').replace(/(?:(^|\n)([+-]|\d+\.) +(.*(\n[ \t]+.*)*))+/g, list)}`)}</li>`)}</${temp}>`
+        `<${temp}>${text.replace(/(?:[+-]|\d+\.) +(.*)\n?(([ \t].*\n?)*)/g, (match, a, b) => `<li>${inlineBlock(a)}\n${outdent(b || '').replace(/(?:(^|\n)([+-]|\d+\.) +(.*(\n[ \t]+.*)*))+/g, list)}</li>`)}</${temp}>`
         : '';
     },
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -121,6 +121,13 @@ describe('md.parse()', () => {
       );
     });
   });
+
+  describe('lists', () => {
+    it('should not double parse nested list contents', () => {
+      expect(md.parse('- a\n  - [b](http://b)')).toEqual('<ul><li>a\n<ul><li><a href="http://b" >b</a>\n</li></ul></li></ul>');
+    });
+  });
+
   //
   // describe('lists', () => {
   //   it('parses an unordered list with *', () => {


### PR DESCRIPTION
Nested lists we're passed through `inlineBlock` n-times where n is the nesting level. This fix passes `a` to `inlineBlock` separate from the list tail (`b`).

Hopefully this doesn't break any other use cases :)

🌴 